### PR TITLE
chore: bump TSTyche to v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ pnpm check
 # Run tests for all packages
 pnpm test
 
+# Run type tests for all packages
+pnpm test:types
+
 # Lint all packages
 pnpm lint
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "format": "prettier -w .",
     "format:check": "prettier -c .",
     "prepack": "pnpm run dist",
-    "test": "pnpm -r test"
+    "test": "pnpm -r test",
+    "test:types": "pnpm -r test:types"
   },
   "devDependencies": {
     "@types/jest": "^29.5.12",

--- a/packages/ast-client/package.json
+++ b/packages/ast-client/package.json
@@ -30,6 +30,6 @@
     "graphql": "^16.8.1"
   },
   "devDependencies": {
-    "tstyche": "1.1.0"
+    "tstyche": "2.0.0"
   }
 }

--- a/packages/ast-client/src/query.test-d.ts
+++ b/packages/ast-client/src/query.test-d.ts
@@ -38,65 +38,65 @@ const emptyRecordQuery = {} as Query<Record<string, never>, MyQueryResult>;
 
 describe("Queries", () => {
   test("are not plain document nodes", () => {
-    expect(myQuery).type.not.toEqual<DocumentNode>();
-    expect(voidQuery).type.not.toEqual<DocumentNode>();
-    expect(undefinedQuery).type.not.toEqual<DocumentNode>();
-    expect(emptyQuery).type.not.toEqual<DocumentNode>();
-    expect(emptyRecordQuery).type.not.toEqual<DocumentNode>();
+    expect(myQuery).type.not.toBe<DocumentNode>();
+    expect(voidQuery).type.not.toBe<DocumentNode>();
+    expect(undefinedQuery).type.not.toBe<DocumentNode>();
+    expect(emptyQuery).type.not.toBe<DocumentNode>();
+    expect(emptyRecordQuery).type.not.toBe<DocumentNode>();
   });
 
   test("All queries are DocumentNodes", () => {
-    expect<DocumentNode>().type.toBeAssignable(myQuery);
-    expect<DocumentNode>().type.toBeAssignable(voidQuery);
-    expect<DocumentNode>().type.toBeAssignable(undefinedQuery);
-    expect<DocumentNode>().type.toBeAssignable(emptyQuery);
-    expect<DocumentNode>().type.toBeAssignable(emptyRecordQuery);
+    expect(myQuery).type.toBeAssignableTo<DocumentNode>();
+    expect(voidQuery).type.toBeAssignableTo<DocumentNode>();
+    expect(undefinedQuery).type.toBeAssignableTo<DocumentNode>();
+    expect(emptyQuery).type.toBeAssignableTo<DocumentNode>();
+    expect(emptyRecordQuery).type.toBeAssignableTo<DocumentNode>();
   });
 
   test("But DocumentNodes are not queries", () => {
-    expect(myQuery).type.not.toBeAssignable<DocumentNode>();
-    expect(voidQuery).type.not.toBeAssignable<DocumentNode>();
-    expect(undefinedQuery).type.not.toBeAssignable<DocumentNode>();
-    expect(emptyQuery).type.not.toBeAssignable<DocumentNode>();
-    expect(emptyRecordQuery).type.not.toBeAssignable<DocumentNode>();
+    expect(myQuery).type.not.toBeAssignableWith<DocumentNode>();
+    expect(voidQuery).type.not.toBeAssignableWith<DocumentNode>();
+    expect(undefinedQuery).type.not.toBeAssignableWith<DocumentNode>();
+    expect(emptyQuery).type.not.toBeAssignableWith<DocumentNode>();
+    expect(emptyRecordQuery).type.not.toBeAssignableWith<DocumentNode>();
   });
 
   test("are not Mutations", () => {
-    expect(myQuery).type.not.toBeAssignable<Mutation<any, any>>();
-    expect(voidQuery).type.not.toBeAssignable<Mutation<any, any>>();
-    expect(undefinedQuery).type.not.toBeAssignable<Mutation<any, any>>();
-    expect(emptyQuery).type.not.toBeAssignable<Mutation<any, any>>();
-    expect(emptyRecordQuery).type.not.toBeAssignable<Mutation<any, any>>();
+    expect(myQuery).type.not.toBeAssignableWith<Mutation<any, any>>();
+    expect(voidQuery).type.not.toBeAssignableWith<Mutation<any, any>>();
+    expect(undefinedQuery).type.not.toBeAssignableWith<Mutation<any, any>>();
+    expect(emptyQuery).type.not.toBeAssignableWith<Mutation<any, any>>();
+    expect(emptyRecordQuery).type.not.toBeAssignableWith<Mutation<any, any>>();
   });
 });
 
 // prettier-ignore
 describe("Client", () => {
   test("If the Query has a non-empty parameter object, the variables parameter is required", () => {
-    expect(runQuery(myQuery, { path: "foo" })).type.toEqual<Promise<MyQueryResult>>();
+    expect(runQuery(myQuery, { path: "foo" })).type.toBe<Promise<MyQueryResult>>();
     expect(runQuery(myQuery)).type.toRaiseError(2554); // "Expected 2 arguments, but got 1."
   });
 
   test("If the query does not require any parameters, we can skip them", () => {
-    expect(runQuery(voidQuery, undefined)).type.toEqual<Promise<MyQueryResult>>();
-    expect(runQuery(voidQuery)).type.toEqual<Promise<MyQueryResult>>();
-    expect(runQuery(undefinedQuery, undefined)).type.toEqual<Promise<MyQueryResult>>();
-    expect(runQuery(undefinedQuery)).type.toEqual<Promise<MyQueryResult>>();
-    expect(runQuery(emptyQuery)).type.toEqual<Promise<MyQueryResult>>();
-    expect(runQuery(emptyQuery, {})).type.toEqual<Promise<MyQueryResult>>();
-    expect(runQuery(emptyRecordQuery)).type.toEqual<Promise<MyQueryResult>>();
-    expect(runQuery(emptyRecordQuery, {})).type.toEqual<Promise<MyQueryResult>>();
+    expect(runQuery(voidQuery, undefined)).type.toBe<Promise<MyQueryResult>>();
+    expect(runQuery(voidQuery)).type.toBe<Promise<MyQueryResult>>();
+    expect(runQuery(undefinedQuery, undefined)).type.toBe<Promise<MyQueryResult>>();
+    expect(runQuery(undefinedQuery)).type.toBe<Promise<MyQueryResult>>();
+    expect(runQuery(emptyQuery)).type.toBe<Promise<MyQueryResult>>();
+    expect(runQuery(emptyQuery, {})).type.toBe<Promise<MyQueryResult>>();
+    expect(runQuery(emptyRecordQuery)).type.toBe<Promise<MyQueryResult>>();
+    expect(runQuery(emptyRecordQuery, {})).type.toBe<Promise<MyQueryResult>>();
   });
 
   test("Empty parameters also accept undefined or empty object", () => {
-    expect(runQuery(voidQuery, undefined)).type.toEqual<Promise<MyQueryResult>>();
-    expect(runQuery(voidQuery, {})).type.toEqual<Promise<MyQueryResult>>();
-    expect(runQuery(undefinedQuery, undefined)).type.toEqual<Promise<MyQueryResult>>();
-    expect(runQuery(undefinedQuery, {})).type.toEqual<Promise<MyQueryResult>>();
-    expect(runQuery(emptyQuery, undefined)).type.toEqual<Promise<MyQueryResult>>();
-    expect(runQuery(emptyQuery, {})).type.toEqual<Promise<MyQueryResult>>();
-    expect(runQuery(emptyRecordQuery, undefined)).type.toEqual<Promise<MyQueryResult>>();
-    expect(runQuery(emptyRecordQuery, {})).type.toEqual<Promise<MyQueryResult>>();
+    expect(runQuery(voidQuery, undefined)).type.toBe<Promise<MyQueryResult>>();
+    expect(runQuery(voidQuery, {})).type.toBe<Promise<MyQueryResult>>();
+    expect(runQuery(undefinedQuery, undefined)).type.toBe<Promise<MyQueryResult>>();
+    expect(runQuery(undefinedQuery, {})).type.toBe<Promise<MyQueryResult>>();
+    expect(runQuery(emptyQuery, undefined)).type.toBe<Promise<MyQueryResult>>();
+    expect(runQuery(emptyQuery, {})).type.toBe<Promise<MyQueryResult>>();
+    expect(runQuery(emptyRecordQuery, undefined)).type.toBe<Promise<MyQueryResult>>();
+    expect(runQuery(emptyRecordQuery, {})).type.toBe<Promise<MyQueryResult>>();
   });
 
   // TODO: Should it though? This could cause issues later when using
@@ -119,20 +119,20 @@ describe("Client", () => {
 
 describe("ResultOf", () => {
   test("ResultOf should resolve to the type of the result", () => {
-    expect<ResultOf<typeof myQuery>>().type.toEqual<MyQueryResult>;
-    expect<ResultOf<typeof voidQuery>>().type.toEqual<MyQueryResult>;
-    expect<ResultOf<typeof undefinedQuery>>().type.toEqual<MyQueryResult>;
-    expect<ResultOf<typeof emptyQuery>>().type.toEqual<MyQueryResult>;
-    expect<ResultOf<typeof emptyRecordQuery>>().type.toEqual<MyQueryResult>;
+    expect<ResultOf<typeof myQuery>>().type.toBe<MyQueryResult>;
+    expect<ResultOf<typeof voidQuery>>().type.toBe<MyQueryResult>;
+    expect<ResultOf<typeof undefinedQuery>>().type.toBe<MyQueryResult>;
+    expect<ResultOf<typeof emptyQuery>>().type.toBe<MyQueryResult>;
+    expect<ResultOf<typeof emptyRecordQuery>>().type.toBe<MyQueryResult>;
   });
 });
 
 describe("VariablesOf", () => {
   test("VariablesOf should resolve to the type of the parameters", () => {
-    expect<VariablesOf<typeof myQuery>>().type.toEqual<MyQueryParams>;
-    expect<VariablesOf<typeof voidQuery>>().type.toEqual<void>;
-    expect<VariablesOf<typeof undefinedQuery>>().type.toEqual<undefined>;
-    expect<VariablesOf<typeof emptyQuery>>().type.toEqual<EmptyObject>;
-    expect<VariablesOf<typeof emptyRecordQuery>>().type.toEqual<EmptyObject>;
+    expect<VariablesOf<typeof myQuery>>().type.toBe<MyQueryParams>;
+    expect<VariablesOf<typeof voidQuery>>().type.toBe<void>;
+    expect<VariablesOf<typeof undefinedQuery>>().type.toBe<undefined>;
+    expect<VariablesOf<typeof emptyQuery>>().type.toBe<EmptyObject>;
+    expect<VariablesOf<typeof emptyRecordQuery>>().type.toBe<EmptyObject>;
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,8 +58,8 @@ importers:
         version: 16.8.1
     devDependencies:
       tstyche:
-        specifier: 1.1.0
-        version: 1.1.0(typescript@5.4.5)
+        specifier: 2.0.0
+        version: 2.0.0(typescript@5.4.5)
 
   packages/example-app:
     dependencies:
@@ -6576,9 +6576,9 @@ packages:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
     dev: true
 
-  /tstyche@1.1.0(typescript@5.4.5):
-    resolution: {integrity: sha512-ZvDeScrBJf6053bdOkGUtnfDn7414XjmjGWrDntQfSmtPvxv9HVJ+03GFK2O46hfoAI9L5Q22uw6xy5ZTBdPGg==}
-    engines: {node: '>=14.17'}
+  /tstyche@2.0.0(typescript@5.4.5):
+    resolution: {integrity: sha512-1LUCZEmMLRL7P0qDNtjx8oEEpU4qVUNggpsitl3XSGyuorbSNfees+EmMDC0VZ9FuClD0Far262U9oAT6Vz83Q==}
+    engines: {node: '>=16.14'}
     hasBin: true
     peerDependencies:
       typescript: 4.x || 5.x


### PR DESCRIPTION
This PR upgrades TSTyche to v2, which was published recently.

The new version ships with the watch mode and renamed / improved matchers. The detailed release notes can be found here: https://tstyche.org/releases/tstyche-2

I have updated the type tests with the new matcher names accordingly.